### PR TITLE
room_idのバグ

### DIFF
--- a/src/components/HomePage.vue
+++ b/src/components/HomePage.vue
@@ -123,7 +123,7 @@ export default {
           `${process.env.VUE_APP_BASE_URL}create_default_room/`,
           {
             room_name: "HomePage",
-            room_id: 0,
+            room_id: 1,
           },
           {
             headers: {


### PR DESCRIPTION
room_idがsqliteでは0を許容するのにmysqlでは許容されないため修正